### PR TITLE
Restore Go 1.13 build compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,10 @@ On Linux and other Unix-like systems, link the math library and omit the `.exe` 
 Building the Go encoder
 =======================
 
+	# Go 1.13 or newer
 	go build -o tscrunch tscrunch.go
+
+Build `tscrunch.go` explicitly as shown above. Running `go build .` in the repository root also includes `tscrunch.c`, which requires cgo and is not needed for the Go encoder.
 
 Building the Java encoder
 =========================

--- a/readme.txt
+++ b/readme.txt
@@ -72,7 +72,10 @@ On Linux and other Unix-like systems, link the math library and omit the .exe su
 Building the Go encoder
 =======================
 
+	# Go 1.13 or newer
 	go build -o tscrunch tscrunch.go
+
+Build tscrunch.go explicitly as shown above. Running go build . in the repository root also includes tscrunch.c, which requires cgo and is not needed for the Go encoder.
 
 Building the Java encoder
 =========================

--- a/tscrunch.go
+++ b/tscrunch.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"math"
 	"os"
 	"runtime"
@@ -110,13 +111,13 @@ func shortestPathForward(transitions []token, starts []int, inputSize int) ([]to
 			destination := position + transition.size
 			relax(position, destination, tokenCost(position, destination, transition.tokentype), transition)
 			if transition.size <= LONGESTLITERAL {
-				specializedLiteralLengths |= uint32(1) << transition.size
+				specializedLiteralLengths |= uint32(1) << uint(transition.size)
 			}
 		}
 		literalLimit := min(LONGESTLITERAL, inputSize-position)
 		for size := 1; size <= literalLimit; size++ {
 			destination := position + size
-			if specializedLiteralLengths&(uint32(1)<<size) != 0 {
+			if specializedLiteralLengths&(uint32(1)<<uint(size)) != 0 {
 				continue
 			}
 			literal := LIT(position, size)
@@ -182,7 +183,7 @@ func max(x, y int) int {
 }
 
 func load_raw(f string) []byte {
-	data, err := os.ReadFile(f)
+	data, err := ioutil.ReadFile(f)
 	if err == nil {
 		return data
 	}
@@ -191,13 +192,14 @@ func load_raw(f string) []byte {
 }
 
 func save_raw(f string, data []byte) {
-	os.WriteFile(f, data, 0666)
+	ioutil.WriteFile(f, data, 0666)
 }
 
 func fillPrefixArray(data []byte, ctx *crunchCtx) {
 	ctx.prefixArray = make(map[[MINLZ]byte][]int)
 	for i := 0; i+MINLZ <= len(data); i++ {
-		key := *(*[MINLZ]byte)(data[i:])
+		var key [MINLZ]byte
+		copy(key[:], data[i:i+MINLZ])
 		ctx.prefixArray[key] = append(ctx.prefixArray[key], i)
 	}
 }
@@ -317,7 +319,8 @@ func findLZCandidates(src []byte, i int, minlz int, ctx *crunchCtx) lzCandidates
 	prefix := src[i : i+minlz]
 	x0 := max(0, i-LONGLZOFFSET)
 	if ctx.usePrefixArray {
-		key := *(*[MINLZ]byte)(prefix)
+		var key [MINLZ]byte
+		copy(key[:], prefix)
 		parray := ctx.prefixArray[key]
 		for o := sort.SearchInts(parray, i) - 1; o >= 0 && parray[o] >= x0; o-- {
 			j := parray[o]


### PR DESCRIPTION
## What changed

- use Go 1.13-compatible file APIs
- replace newer slice-to-array-pointer conversions with explicit key copies
- use unsigned shift counts for compatibility with the reported gccgo toolchain
- document the supported Go version and the correct single-file build command

## Root cause

The Go encoder had adopted APIs and conversions introduced after Go 1.13. Building the repository as a package also includes `tscrunch.c`, which is not needed for the Go encoder and requires cgo.

## Validation

- built successfully with Go 1.13.15
- built successfully and passed `go vet` with the current Go toolchain
- both builds produced byte-identical compressed output for the same input

Fixes #6